### PR TITLE
[FEATURE] Add enUS aria-live for toggling the token highlight - RN-39311

### DIFF
--- a/languages/en-US/label_bundles/questions-api.json
+++ b/languages/en-US/label_bundles/questions-api.json
@@ -242,7 +242,9 @@
             "correctAnswers": "correct answers: {{answers}} ",
             "incorrectAnswers": "incorrect answers: {{answers}} ",
             "expectedAnswers": "expected answers: {{answers}} ",
-            "explanation": "To interact with this question use tab to move through the text tokens. Use space or enter to select or deselect the relevant tokens"
+            "explanation": "To interact with this question use tab to move through the text tokens. Use space or enter to select or deselect the relevant tokens",
+            "highlighted": "Highlighted: {{content}}",
+            "notHighlighted": "Not highlighted: {{content}}"
         },
         "clozeAssociation": {
             "activatedResponse": "The option \"{{response}}\" ({{responseNumber}} of {{totalResponses}}) has been selected. Press tab to choose a response area, and spacebar to insert it. Press escape to cancel.",


### PR DESCRIPTION
JIRA: [LRN-39311](https://learnosity.atlassian.net/browse/LRN-39311)

- Added the aria-live text in en-US  for toggling the token highlight

[LRN-39311]: https://learnosity.atlassian.net/browse/LRN-39311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ